### PR TITLE
Refact/ Separating logic from main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,13 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from typing import List, Optional
 import json
 import pandas as pd
 import Thermobar as TB
 
-from utils.utils import rename_duplicate_columns
-from services.calculations_service import function_constructor
-from utils.models import calculationRequest, calculationResponse
+from app.services.calculations_service import argument_constructor
+from app.utils.utils import rename_duplicate_columns
+from app.services.calculations_service import function_constructor
+from app.utils.models import calculationRequest, calculationResponse
 
 # Create an instance of the app
 appCalculationThermobar = FastAPI()
@@ -56,13 +55,17 @@ async def calculate(request: calculationRequest):
     # Creating the function name and the arguments for the different cases ___________________________________
 
     function_name = function_constructor(userData.iterative,
+                                         userData.equationP,
+                                         userData.equationT,
+                                         userData.phaseConcat)
+
+    arguments = argument_constructor(userData.iterative,
                                          userData.tDependant,
                                          userData.pDependant,
                                          userData.h2oDependant,
                                          userData.equationP,
                                          userData.equationT,
                                          phaseArg,
-                                         phaseConcat,
                                          userData.temperature,
                                          userData.pressure,
                                          userData.h2o)

--- a/app/services/calculations_service.py
+++ b/app/services/calculations_service.py
@@ -1,22 +1,77 @@
-def function_constructor(iterative, tDependant, pDependant, h2oDependant, equationP, equationT, phaseArg, phaseConcat, temperature, pressure, h2o):
+"""
+### Dynamic function constructor
+
+Construct the function name used based on the input of the user.
+
+:param iterative: Is the calculation mode iterative? Equation for both P and T must be provided. *(bool)*
+:param equationP: Equation chosen to calculate P. *(str || null)*
+:param equationT: Equation chosen to calculate T. *(str || null)*
+:param phaseConcat: Used phases used for calculations. *(str)*
+
+:return: the name of the function to call *(str)*.
+___________
+"""
+
+def function_constructor(iterative, equationP, equationT, phaseConcat):
 
     if iterative:
 
         # Construct the name of the function using the phases provided by the userData object
         functionName = f'calculate{phaseConcat}_press_temp'
 
-        # Construction of the arguments of the function and function call (arg)
-        eqArg = f'equationP="{equationP}", equationT="{equationT}", '
-        arguments = phaseArg + eqArg + 'eq_tests=True'
+        return functionName
 
     elif equationP is not None : # Case to calculate P
 
         # Construct the name of the fonction using the phases provided by the userData object
         functionName = f'calculate{phaseConcat}_press, '
 
+        return functionName
+
+    elif equationT is not None : # Case to calculate T
+
+        # Construct the name of the fonction using the phases provided by the userData object
+        functionName = f'calculate{phaseConcat}_temp, '
+
+        return functionName
+
+    else :
+
+        # if no equation is passed (SHOULD NOT HAPPEN) the system shutdown
+        print(f"No equation passed shutting down")
+
+def argument_constructor(iterative, tDependant, pDependant, h2oDependant, equationP, equationT, phaseArg, temperature, pressure, h2o):
+    """
+    ### Dynamic argument constructor
+
+    Construct the arguments used by the function defined in function_constructor.
+
+    :param iterative: Is the calculation mode iterative? Equation for both P and T must be provided. *(bool)*
+    :param tDependant: Is one of the equation chosen equation is temperature-dependant ? *(bool)*
+    :param pDependant: Is one of the equation chosen equation is pressure-dependant ? *(bool)*
+    :param h2oDependant: Is one of the equation chosen equation is water content-dependant ? *(bool)*
+    :param equationP: Equation chosen to calculate P. *(str || null)*
+    :param equationT: Equation chosen to calculate T. *(str || null)*
+    :param phaseArg: Name of the dictionary(ies) containing the compositions of the phases used for calculations. *(str)*
+    :param temperature: Temperature in K. *(float || null)*
+    :param pressure: Pressure in kbar. *(float || null)*
+    :param h2o: Water content in %wt. . *(float || null)*
+
+    :return: the arguments used by the function *(str)*.
+    ___________
+    """
+
+    if iterative:
+
+        # Construction of the arguments of the function and function call (arg)
+        eqArg = f'equationP="{equationP}", equationT="{equationT}", '
+        arguments = phaseArg + eqArg + 'eq_tests=True'
+
+        return arguments
+
+    elif equationP is not None : # Case to calculate P
+
         eqArg = f'equationP="{equationP}", '
-        tempArg = ''
-        h2oArg = ''
 
         if tDependant: # If the equation is temperature dependant the temperature argument is added
             tempArg = f'T = {temperature}, '
@@ -27,13 +82,11 @@ def function_constructor(iterative, tDependant, pDependant, h2oDependant, equati
         # Construction of the arguments of the function and function call (arg)
         arguments = phaseArg + eqArg + tempArg + h2oArg + 'eq_tests=True'
 
+        return arguments
+
     elif equationT is not None : # Case to calculate T
-        # Construct the name of the fonction using the phases provided by the userData object
-        functionName = f'calculate{phaseConcat}_temp, '
 
         eqArg = f'equationT="{equationT}", '
-        pressArg = ''
-        h2oArg = ''
 
         if pDependant: # If the equation is temperature dependant the temperature argument is added
             pressArg = f'P = {pressure} ,'
@@ -44,7 +97,8 @@ def function_constructor(iterative, tDependant, pDependant, h2oDependant, equati
         # Construction of the arguments of the function and function call (arg)
         arguments = phaseArg + eqArg + pressArg + h2oArg + 'eq_tests=True'
 
+        return arguments
+
     else :
         # if no equation is passed (SHOULD NOT HAPPEN) the system shutdown
         print(f"No equation passed shutting down")
-        raise SystemExit

--- a/app/services/calculations_service.py
+++ b/app/services/calculations_service.py
@@ -1,0 +1,50 @@
+def function_constructor(iterative, tDependant, pDependant, h2oDependant, equationP, equationT, phaseArg, phaseConcat, temperature, pressure, h2o):
+
+    if iterative:
+
+        # Construct the name of the function using the phases provided by the userData object
+        functionName = f'calculate{phaseConcat}_press_temp'
+
+        # Construction of the arguments of the function and function call (arg)
+        eqArg = f'equationP="{equationP}", equationT="{equationT}", '
+        arguments = phaseArg + eqArg + 'eq_tests=True'
+
+    elif equationP is not None : # Case to calculate P
+
+        # Construct the name of the fonction using the phases provided by the userData object
+        functionName = f'calculate{phaseConcat}_press, '
+
+        eqArg = f'equationP="{equationP}", '
+        tempArg = ''
+        h2oArg = ''
+
+        if tDependant: # If the equation is temperature dependant the temperature argument is added
+            tempArg = f'T = {temperature}, '
+
+        if h2oDependant: # If the equation is water content dependant the water content argument is added
+            h2oArg = f'H2O_Liq = {h2o}, '
+
+        # Construction of the arguments of the function and function call (arg)
+        arguments = phaseArg + eqArg + tempArg + h2oArg + 'eq_tests=True'
+
+    elif equationT is not None : # Case to calculate T
+        # Construct the name of the fonction using the phases provided by the userData object
+        functionName = f'calculate{phaseConcat}_temp, '
+
+        eqArg = f'equationT="{equationT}", '
+        pressArg = ''
+        h2oArg = ''
+
+        if pDependant: # If the equation is temperature dependant the temperature argument is added
+            pressArg = f'P = {pressure} ,'
+
+        if h2oDependant: # If the equation is water content dependant the water content argument is added
+            h2oArg = f'H2O_Liq = {h2o} ,'
+
+        # Construction of the arguments of the function and function call (arg)
+        arguments = phaseArg + eqArg + pressArg + h2oArg + 'eq_tests=True'
+
+    else :
+        # if no equation is passed (SHOULD NOT HAPPEN) the system shutdown
+        print(f"No equation passed shutting down")
+        raise SystemExit

--- a/app/utils/models.py
+++ b/app/utils/models.py
@@ -7,72 +7,32 @@ The models used serialize and validate the data exchanged with the Front-End.
 """
 
 class calculationRequest(BaseModel):
-    """Calculation request model correspond to what the Back-End receive from the Front-End """
+
+    """
+    Calculation request model correspond to what the Front-End send to the Back-End
+    """
 
     phases: List[str]
-    """phases: a list of the phases used for calculation, can contain only one phase (ex: clinopyroxene)
-    or two (ex: amphibole, liquid) (list[str])"""
-
     system: str
-    """system: similar to phases (str)"""
-
     data: str
-    """data: data used for calculations, correspond to the compositions of minerals, handled to the
-       front-end as a table and converted to a single string (string)"""
-
     iterative: bool
-    """iterative: if both temperature and pressure are calculated iteratively (boolean)"""
-
     equationP: Optional[str]
-    """(optional) equationP: if the mode selected require the use of an equation to calculate P this
-       equation is given here (string)"""
-
     equationT: Optional[str]
-    """(optional) equationT: if the mode selected require the use of an equation to calculate T this
-       equation is given here (string)"""
-
     pDependant: bool
-    """pDependant: if one of the selected equation is dependant the pressure (boolean)"""
-
     tDependant: bool
-    """tDependant: if one of the selected equation is dependant on the temperature (boolean)"""
-
     h2oDependant: bool
-    """h2oDependant: if one of the selected equation is dependant on the water content of the melt (boolean)"""
-
     pressure: Optional[float]
-    """(optional) pressure: if one of the selected equation require the pressure (float - kbar)"""
-
     temperature: Optional[float]
-    """(optional) temperature: if one of the selected equation require the temperature  (float - K)"""
-
     h2o: Optional[float]
-    """(optional) h2o: if one of the selected equation require the water content of the melt (float - %wt.)"""
 
 
 class calculationResponse(BaseModel):
-    """Calculation request model correspond to what the Back-End back send to the Front-End """
+    """Calculation response model correspond to what the Back-End send back to the Front-End """
 
     phases: List[str]
-    """phases: a list of the phases used for calculation, can contain only one phase (list[str])"""
-
     data: str
-    """data: data used for calculations, correspond to the compositions of minerals, handled to the
-       front-end as a table and converted to a single string (string)"""
-
     equationP: Optional[str]
-    """(optional) equationP: if the mode selected require the use of an equation to calculate P this
-       equation is given here (string)"""
-
     equationT: Optional[str]
-    """(optional) equationT: if the mode selected require the use of an equation to calculate T this
-       equation is given here (string)"""
-
     pressure: Optional[float]
-    """(optional) pressure: if one of the selected equation require the pressure (float - kbar)"""
-
     temperature: Optional[float]
-    """(optional) temperature: if one of the selected equation require the temperature  (float - K)"""
-
     h2o: Optional[float]
-    """(optional) h2o: if one of the selected equation require the water content of the melt (float - %wt.)"""

--- a/app/utils/models.py
+++ b/app/utils/models.py
@@ -1,0 +1,78 @@
+# Create an object of what the application receive
+from typing import Optional, List
+from pydantic import BaseModel
+
+"""
+The models used serialize and validate the data exchanged with the Front-End.
+"""
+
+class calculationRequest(BaseModel):
+    """Calculation request model correspond to what the Back-End receive from the Front-End """
+
+    phases: List[str]
+    """phases: a list of the phases used for calculation, can contain only one phase (ex: clinopyroxene)
+    or two (ex: amphibole, liquid) (list[str])"""
+
+    system: str
+    """system: similar to phases (str)"""
+
+    data: str
+    """data: data used for calculations, correspond to the compositions of minerals, handled to the
+       front-end as a table and converted to a single string (string)"""
+
+    iterative: bool
+    """iterative: if both temperature and pressure are calculated iteratively (boolean)"""
+
+    equationP: Optional[str]
+    """(optional) equationP: if the mode selected require the use of an equation to calculate P this
+       equation is given here (string)"""
+
+    equationT: Optional[str]
+    """(optional) equationT: if the mode selected require the use of an equation to calculate T this
+       equation is given here (string)"""
+
+    pDependant: bool
+    """pDependant: if one of the selected equation is dependant the pressure (boolean)"""
+
+    tDependant: bool
+    """tDependant: if one of the selected equation is dependant on the temperature (boolean)"""
+
+    h2oDependant: bool
+    """h2oDependant: if one of the selected equation is dependant on the water content of the melt (boolean)"""
+
+    pressure: Optional[float]
+    """(optional) pressure: if one of the selected equation require the pressure (float - kbar)"""
+
+    temperature: Optional[float]
+    """(optional) temperature: if one of the selected equation require the temperature  (float - K)"""
+
+    h2o: Optional[float]
+    """(optional) h2o: if one of the selected equation require the water content of the melt (float - %wt.)"""
+
+
+class calculationResponse(BaseModel):
+    """Calculation request model correspond to what the Back-End back send to the Front-End """
+
+    phases: List[str]
+    """phases: a list of the phases used for calculation, can contain only one phase (list[str])"""
+
+    data: str
+    """data: data used for calculations, correspond to the compositions of minerals, handled to the
+       front-end as a table and converted to a single string (string)"""
+
+    equationP: Optional[str]
+    """(optional) equationP: if the mode selected require the use of an equation to calculate P this
+       equation is given here (string)"""
+
+    equationT: Optional[str]
+    """(optional) equationT: if the mode selected require the use of an equation to calculate T this
+       equation is given here (string)"""
+
+    pressure: Optional[float]
+    """(optional) pressure: if one of the selected equation require the pressure (float - kbar)"""
+
+    temperature: Optional[float]
+    """(optional) temperature: if one of the selected equation require the temperature  (float - K)"""
+
+    h2o: Optional[float]
+    """(optional) h2o: if one of the selected equation require the water content of the melt (float - %wt.)"""

--- a/app/utils/utils.py
+++ b/app/utils/utils.py
@@ -1,0 +1,16 @@
+# Function to correct if there is duplicated column names (which case the change to a json will fail at the end of calculations)
+def rename_duplicate_columns(df):
+
+    new_columns = []
+    column_count = {}
+
+    for col in df.columns:
+        if col in column_count:
+            column_count[col] += 1
+            new_columns.append(f"{col}_{column_count[col]}")
+        else:
+            column_count[col] = 0
+            new_columns.append(col)
+
+    df.columns = new_columns
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 Thermobar
 pydantic
 pytest
+pdoc


### PR DESCRIPTION
# Refactorisation of the logic

The initial project had the entire logic only in the main.py file. For clarity sake and future development of the app here is what I did and why:

### Created the "services" folder

This folder is destined to host the business logic as well as the interactions with external ressources.

### Created the "utils" folder

This folder contains mostly small function that can be used anywhere to help (such as parser for example)

# Added doc support

By adding the "pdoc" library it is now possible to write documentation for the function.
Then added bits of documentation in calculations_service.py and models.py